### PR TITLE
Fix COPY command output to local file

### DIFF
--- a/src/syncer.go
+++ b/src/syncer.go
@@ -175,9 +175,10 @@ func (syncer *Syncer) exportPgTableToCsv(conn *pgx.Conn, pgSchemaTable SchemaTab
 	PanicIfError(err)
 	defer DeleteTemporaryFile(tempFile)
 
-	result, err := conn.Exec(
+	result, err := conn.PgConn().CopyTo(
 		context.Background(),
-		"COPY "+pgSchemaTable.String()+" TO '"+tempFile.Name()+"' WITH CSV HEADER",
+		tempFile,
+		"COPY "+pgSchemaTable.String()+" TO STDOUT WITH CSV HEADER",
 	)
 	PanicIfError(err)
 	LogDebug(syncer.config, "Copied", result.RowsAffected(), "row(s) into", tempFile.Name())


### PR DESCRIPTION
Thank you for developing such a wonderful tool.   
While trying it locally, I encountered an issue that I think might be a problem(may be related to https://github.com/BemiHQ/BemiDB/issues/2), and I would like to propose the following changes.


# Problem

During synchronization, the process fails when attempting to read from a temporary file, resulting in an EOF (End of File) error.
The error occurs at [this](https://github.com/BemiHQ/BemiDB/blob/f9e78f2805810e32b80281d2589c2bae4efea2ee/src/syncer.go#L102) point.

```
bemidb    | panic: EOF
bemidb    |
bemidb    | goroutine 1 [running]:
bemidb    | main.PanicIfError({0x27dd9a0?, 0x34c2640?}, {0x0?, 0x2673c0f?, 0x40002045f8?})
bemidb    |     /app/utils.go:14 +0x9c
bemidb    | main.(*Syncer).syncFromPgTable(0x40002161e0, 0x4000000c60, {{0x40002045b8?, 0x6?}, {0x40002045f8?, 0x0?}})
bemidb    |     /app/syncer.go:108 +0x2f4
bemidb    | main.(*Syncer).SyncFromPostgres(0x40002161e0)
bemidb    |     /app/syncer.go:46 +0x1a8
bemidb    | main.syncFromPg(0x355f440)
bemidb    |     /app/main.go:60 +0x24
bemidb    | main.main()
bemidb    |     /app/main.go:25 +0xb0
```

# Solution

Previously, the COPY command was executed in a way that created the result file on the Postgres server:

```
result, err := conn.Exec(
    context.Background(),
    "COPY " + pgSchemaTable.String() + " TO '" + tempFile.Name() + "' WITH CSV HEADER",
)
```

I think that creating the file locally is the intended behavior, and I would like to propose the following changes to align with that.

```
result, err := conn.PgConn().CopyTo(
	context.Background(),
	tempFile,
	"COPY "+pgSchemaTable.String()+" TO STDOUT WITH CSV HEADER",
)
```
