### PR TITLE
Upgrade pg_query_go to v6

### DIFF
--- a/src/server/go.mod
+++ b/src/server/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/marcboeker/go-duckdb/v2 v2.3.2
-	github.com/pganalyze/pg_query_go/v5 v5.1.0
+	github.com/pganalyze/pg_query_go/v6 v6.1.0
 )
 
 require golang.org/x/crypto v0.35.0

--- a/src/server/go.sum
+++ b/src/server/go.sum
@@ -93,8 +93,8 @@ github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpsp
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
-github.com/pganalyze/pg_query_go/v5 v5.1.0 h1:MlxQqHZnvA3cbRQYyIrjxEjzo560P6MyTgtlaf3pmXg=
-github.com/pganalyze/pg_query_go/v5 v5.1.0/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
+github.com/pganalyze/pg_query_go/v6 v6.1.0 h1:jG5ZLhcVgL1FAw4C/0VNQaVmX1SUJx71wBGdtTtBvls=
+github.com/pganalyze/pg_query_go/v6 v6.1.0/go.mod h1:nvTHIuoud6e1SfrUaFwHqT0i4b5Nr+1rPWVds3B5+50=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/src/server/parser_a_expr.go
+++ b/src/server/parser_a_expr.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type ParserAExpr struct {

--- a/src/server/parser_column_ref.go
+++ b/src/server/parser_column_ref.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type ParserColumnRef struct {

--- a/src/server/parser_function.go
+++ b/src/server/parser_function.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type ParserFunction struct {

--- a/src/server/parser_select.go
+++ b/src/server/parser_select.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type ParserSelect struct {

--- a/src/server/parser_show.go
+++ b/src/server/parser_show.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type ParserShow struct {

--- a/src/server/parser_table.go
+++ b/src/server/parser_table.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type QueryToIcebergTable struct {

--- a/src/server/parser_type_cast.go
+++ b/src/server/parser_type_cast.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type ParserTypeCast struct {

--- a/src/server/parser_utils.go
+++ b/src/server/parser_utils.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type ParserUtils struct {

--- a/src/server/query_remapper.go
+++ b/src/server/query_remapper.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 var SUPPORTED_SET_STATEMENTS = NewSet[string]().AddAll([]string{

--- a/src/server/query_remapper_expression.go
+++ b/src/server/query_remapper_expression.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type QueryRemapperExpression struct {

--- a/src/server/query_remapper_function.go
+++ b/src/server/query_remapper_function.go
@@ -3,7 +3,7 @@ package main
 import (
 	"regexp"
 
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 var PG_CATALOG_MACRO_FUNCTION_NAMES = Set[string]{}

--- a/src/server/query_remapper_select.go
+++ b/src/server/query_remapper_select.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type QueryRemapperSelect struct {

--- a/src/server/query_remapper_show.go
+++ b/src/server/query_remapper_show.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 type QueryRemapperShow struct {

--- a/src/server/query_remapper_table.go
+++ b/src/server/query_remapper_table.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	pgQuery "github.com/pganalyze/pg_query_go/v5"
+	pgQuery "github.com/pganalyze/pg_query_go/v6"
 )
 
 var PG_CATALOG_TABLE_NAMES = Set[string]{}


### PR DESCRIPTION
Hi, thanks for BemiDB!

Building on macOS 15.5 currently fails with:

```text
# github.com/pganalyze/pg_query_go/v5/parser
src_port_snprintf.c:374:1: error: static declaration of 'strchrnul' follows non-static declaration
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_string.h:198:9: note: previous declaration is here
src_port_snprintf.c:438:27: warning: 'strchrnul' is only available on macOS 15.4 or newer [-Wunguarded-availability-new]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_string.h:198:9: note: 'strchrnul' has been marked as being introduced in macOS 15.4 here, but the deployment target is macOS 15.0.0
src_port_snprintf.c:438:27: note: enclose 'strchrnul' in a __builtin_available check to silence this warning
```

This is fixed in pg_query_go v6.1.0: https://github.com/pganalyze/pg_query_go/issues/132