### PR TITLE
fix: recursively process all expressions in COALESCE arguments

### DIFF
--- a/src/server/query_handler_test.go
+++ b/src/server/query_handler_test.go
@@ -195,7 +195,7 @@ func TestHandleQuery(t *testing.T) {
 			},
 			"SELECT jsonb_array_length('[1, 2, 3]'::jsonb)": {
 				"description": {"jsonb_array_length"},
-				"types":       {uint32ToString(pgtype.XID8OID)},
+				"types":       {uint32ToString(pgtype.Int4OID)},
 				"values":      {"3"},
 			},
 			"SELECT jsonb_pretty('{\"key\": \"value\"}'::JSONB)": {
@@ -257,6 +257,16 @@ func TestHandleQuery(t *testing.T) {
 				"description": {"datname"},
 				"types":       {uint32ToString(pgtype.TextOID)},
 				"values":      {"bemidb"},
+			},
+			"SELECT COALESCE(NULL, '[]'::jsonb) AS json_value": {
+				"description": {"json_value"},
+				"types":       {uint32ToString(pgtype.JSONOID)},
+				"values":      {"[]"},
+			},
+			"SELECT jsonb_array_length(COALESCE('[]'::jsonb, '{}'::jsonb)) AS length": {
+				"description": {"length"},
+				"types":       {uint32ToString(pgtype.Int4OID)},
+				"values":      {"0"},
 			},
 			"SELECT * FROM pg_catalog.pg_stat_gssapi": {
 				"description": {"pid", "gss_authenticated", "principal", "encrypted", "credentials_delegated"},

--- a/src/server/query_remapper.go
+++ b/src/server/query_remapper.go
@@ -354,11 +354,9 @@ func (remapper *QueryRemapper) remappedExpressions(node *pgQuery.Node, remappedC
 	// COALESCE(value1, value2, ...)
 	coalesceExpr := node.GetCoalesceExpr()
 	if coalesceExpr != nil {
-		for _, arg := range coalesceExpr.Args {
-			if arg.GetSubLink() != nil {
-				// Nested SELECT
-				subSelect := arg.GetSubLink().Subselect.GetSelectStmt()
-				remapper.remapSelectStatement(subSelect, permissions, indentLevel+1) // recursion
+		for i, arg := range coalesceExpr.Args {
+			if arg != nil {
+				coalesceExpr.Args[i] = remapper.remappedExpressions(arg, remappedColumnRefs, permissions, indentLevel+1) // self-recursion
 			}
 		}
 	}

--- a/src/server/query_remapper_function.go
+++ b/src/server/query_remapper_function.go
@@ -42,7 +42,7 @@ func CreatePgCatalogMacroQueries(config *Config) []string {
 			ELSE json_extract_path_text(from_json, path_elems)::varchar
 		END`,
 		`CREATE MACRO jsonb_object_agg(key, value) AS to_json(map(array_agg(key), array_agg(value)))`,
-		`CREATE MACRO jsonb_array_length(json) AS json_array_length(json)`,
+		`CREATE MACRO jsonb_array_length(json) AS CAST(json_array_length(json) AS INTEGER)`,
 		`CREATE MACRO jsonb_pretty(json) AS json_pretty(json)`,
 		`CREATE MACRO json_array_elements(json) AS unnest(json_extract(json, '$[*]'))`,
 		`CREATE MACRO jsonb_array_elements(json) AS unnest(json_extract(json, '$[*]'))`,


### PR DESCRIPTION

The COALESCE expression handler was only processing SubLink (nested SELECT)
arguments, but not other expression types like TypeCast nodes. This caused
queries with '[]'::jsonb inside COALESCE to fail with "Type jsonb does not
exist" errors, since the ::jsonb->::json remapping never occurred.

Changed COALESCE handler to recursively process all argument types using
remappedExpressions(), matching the pattern used for function calls and
boolean expressions. This ensures type casts and other expressions are
properly remapped regardless of nesting context.

Added test coverage for COALESCE with jsonb type casts.